### PR TITLE
Add Codex skill metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Current v0.1 scope:
 - dataroom views/viewers
 - dataroom views-count
 - dataroom stats
-- dataroom export job inspection
+- existing dataroom export job inspection
 
 ## Install
 
@@ -88,7 +88,7 @@ papermark datarooms views <id> --json
 papermark datarooms views-count <id> --json
 papermark datarooms viewers <id> --json
 papermark datarooms stats <id> --json
-papermark datarooms export-visits <id> --json
+papermark datarooms export-visits <id> --json  # inspect existing export jobs
 ```
 
 ## Design notes
@@ -98,7 +98,7 @@ papermark datarooms export-visits <id> --json
 - A typical flow is: `datarooms list`, pick the dataroom id you need, then follow with `get`, `folders`, and analytics/access commands.
 - `datarooms folders` returns a limited summary by default. Use `--limit` to widen the summary or `--raw` for the full nested tree.
 - `doctor` proves auth, team resolution, and dataroom listing. It is a fast sanity check, not a full sweep of every route.
-- `export-visits` currently inspects existing export jobs via a GET route. Triggering new export jobs can be added later if the hosted behavior proves stable enough.
+- `export-visits` is read-only: it inspects existing export jobs via a GET route. It does not create or start a new export.
 - Runtime outputs can contain sensitive dataroom structure, analytics, access-control, and viewer information. Treat command output as private workspace data.
 
 ## Contract

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm i -g papermark-cli
 papermark --help
 ```
 
+Install the agent skill:
+
+```bash
+npx -y skills add -g danielgwilson/papermark-cli --skill papermark
+```
+
 Local:
 
 ```bash

--- a/docs/CONTRACT_V1.md
+++ b/docs/CONTRACT_V1.md
@@ -76,4 +76,4 @@ Current v1 coverage:
 - The CLI depends on an authenticated Papermark browser session or stored session token.
 - The CLI currently models dataroom contents via the folder route rather than the top-level documents route.
 - `datarooms folders` returns a limited summarized view by default; `--limit` widens it and `--raw` returns the full nested payload.
-- `export-visits` currently inspects existing export jobs and does not yet trigger new exports.
+- `export-visits` is read-only: it inspects existing export jobs and does not create or start a new export.

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "npm run typecheck",
     "lint:public-surface": "node scripts/public-surface-check.mjs",
+    "secret-sweep": "bash scripts/secret-sweep.sh",
+    "check:release": "npm run typecheck && npm test && npm run lint:public-surface && npm run secret-sweep",
     "pretest": "npm run build",
     "test": "tsx --test",
     "start": "node dist/cli.js",
-    "prepublishOnly": "npm run lint && npm run lint:public-surface && npm test",
+    "prepublishOnly": "npm run check:release",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/scripts/secret-sweep.sh
+++ b/scripts/secret-sweep.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+capture_hits="$(
+  find "$root" \
+    -type f \
+    \( \
+      -name '*.har' -o \
+      -name '*.har.gz' -o \
+      -name '*.trace' -o \
+      -name '*.trace.json' -o \
+      -name 'storage-state.json' -o \
+      -name 'cookies.txt' -o \
+      -name 'cookies.json' -o \
+      -name '*.session.json' \
+    \) \
+    -not -path '*/.git/*' \
+    -not -path '*/node_modules/*' \
+    -not -path '*/dist/*' \
+    -not -path '*/coverage/*' \
+    -not -path '*/.next/*' \
+    -not -path '*/.firecrawl/*' \
+    -print 2>/dev/null | sort -u
+)"
+
+secret_pattern='((PAPERMARK_SESSION_TOKEN|PAPERMARK_CURRENT_TEAM_ID)=[A-Za-z0-9._~+/=-]{16,}|"(sessionToken|currentTeamId)"[[:space:]]*:[[:space:]]*"[A-Za-z0-9._~+/=-]{16,}"|AQ\.[A-Za-z0-9._-]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{20,}|gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk_live_[A-Za-z0-9]{16,}|xox[baporsc]-[A-Za-z0-9-]{10,}|ya29\.[A-Za-z0-9\-_]+)'
+
+secret_hits="$(
+  rg -n \
+    --hidden \
+    --glob '!**/.git/**' \
+    --glob '!**/node_modules/**' \
+    --glob '!**/dist/**' \
+    --glob '!**/coverage/**' \
+    --glob '!**/.next/**' \
+    --glob '!**/.firecrawl/**' \
+    --glob '!**/.env' \
+    --glob '!**/.env.*' \
+    --glob '!**/*.min.*' \
+    "$secret_pattern" \
+    "$root" 2>/dev/null || true
+)"
+
+exit_code=0
+
+if [ -n "$capture_hits" ]; then
+  exit_code=1
+  printf 'Suspicious capture files:\n%s\n\n' "$capture_hits"
+fi
+
+if [ -n "$secret_hits" ]; then
+  exit_code=1
+  printf 'Secret-like strings:\n%s\n\n' "$secret_hits"
+fi
+
+if [ "$exit_code" -eq 0 ]; then
+  printf 'No suspicious captures or secret-like strings found in %s\n' "$root"
+fi
+
+exit "$exit_code"

--- a/skills/papermark/SKILL.md
+++ b/skills/papermark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: papermark
-description: Use this skill whenever you need to inspect Papermark datarooms via the agent-first `papermark` CLI. Triggers include listing datarooms, inspecting one dataroom, reading folder structures, checking links, groups, permission groups, viewers, views, stats, or export-visits jobs.
+description: Use this skill whenever you need to inspect Papermark datarooms via the agent-first `papermark` CLI. Triggers include listing datarooms, inspecting one dataroom, reading folder structures, checking links, groups, permission groups, viewers, views, stats, or existing export-visits jobs.
 ---
 
 # Papermark (agent-first CLI)
@@ -29,7 +29,7 @@ Default stance:
 - Inspect analytics summary counts: `papermark datarooms views-count <id> --json`
 - Inspect viewers: `papermark datarooms viewers <id> --json`
 - Inspect room stats: `papermark datarooms stats <id> --json`
-- Inspect export jobs: `papermark datarooms export-visits <id> --json`
+- Inspect existing export jobs: `papermark datarooms export-visits <id> --json`
 
 ## Worked example
 
@@ -57,7 +57,7 @@ Treat dataroom, analytics, links, groups, and viewer output as sensitive workspa
 
 - This adapter targets a private authenticated surface, not a documented public management API.
 - Dataroom content is folder-first.
-- `export-visits` currently inspects export jobs and does not yet start them.
+- `export-visits` is read-only: it inspects existing export jobs and does not create or start a new export.
 
 ## Contract essentials
 

--- a/skills/papermark/agents/openai.yaml
+++ b/skills/papermark/agents/openai.yaml
@@ -1,7 +1,10 @@
 interface:
   display_name: "Papermark"
   short_description: "Inspect Papermark datarooms and analytics."
-  default_prompt: "Use $papermark to inspect datarooms, folders, viewers, views, and export-visits jobs."
+  icon_small: "./assets/papermark-small.svg"
+  icon_large: "./assets/papermark.svg"
+  brand_color: "#334155"
+  default_prompt: "Use $papermark to inspect Papermark datarooms, folders, links, access groups, viewers, views, stats, and existing export-visits jobs."
 
 policy:
   allow_implicit_invocation: true

--- a/skills/papermark/assets/papermark-small.svg
+++ b/skills/papermark/assets/papermark-small.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <rect width="24" height="24" fill="#12343B" rx="6"/>
+  <path fill="#F5F7F2" d="M7 5.5h7.2L17 8.3v10.2H7v-13Z"/>
+  <path fill="#12343B" d="M14 5.5v3h3L14 5.5Z"/>
+  <path stroke="#2CA58D" stroke-linecap="round" stroke-width="1.6" d="M9.8 12h4.4M9.8 15h3.2"/>
+</svg>

--- a/skills/papermark/assets/papermark.svg
+++ b/skills/papermark/assets/papermark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" fill="none" viewBox="0 0 96 96">
+  <rect width="96" height="96" fill="#12343B" rx="20"/>
+  <path fill="#F5F7F2" d="M28 18h29l11 11v49H28V18Z"/>
+  <path fill="#D8E2DC" d="M57 18v12h11L57 18Z"/>
+  <path stroke="#2CA58D" stroke-linecap="round" stroke-width="5" d="M38 42h20M38 54h20M38 66h13"/>
+</svg>


### PR DESCRIPTION
Adds nested Codex skill metadata, neutral SVG assets, and release-surface checks for the adapter skill. Verified locally: npm run check:release, npm audit --omit=dev --json, npm pack --dry-run --json --silent, built CLI --help/doctor --json, temp-home skills add proof, and parent workspace secret sweep.